### PR TITLE
FIX : Correct ModuleBuilder left menu

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -2848,7 +2848,7 @@ elseif (!empty($module))
 						print '</td>';
 
 						print '<td>';
-						print $menu['left'];
+						print $menu['leftmenu'];
 						print '</td>';
 
 						print '<td>';


### PR DESCRIPTION
Left menu is 'leftmenu' not 'left'